### PR TITLE
Add Genie greeting message

### DIFF
--- a/src/main/java/genie/MainWindow.java
+++ b/src/main/java/genie/MainWindow.java
@@ -28,6 +28,7 @@ public class MainWindow extends AnchorPane {
     @FXML
     public void initialize() {
         scrollPane.vvalueProperty().bind(dialogContainer.heightProperty());
+        showGreeting();
     }
 
     public void setDuke(Genie g) {
@@ -47,5 +48,12 @@ public class MainWindow extends AnchorPane {
                 DialogBox.getDukeDialog(response, dukeImage)
         );
         userInput.clear();
+    }
+    @FXML
+    private void showGreeting() {
+        String greeting = "Hello! This is Genie, your personal task tracker!\n";
+        dialogContainer.getChildren().addAll(
+                DialogBox.getDukeDialog(greeting, dukeImage)
+        );
     }
 }

--- a/src/main/java/genie/Ui.java
+++ b/src/main/java/genie/Ui.java
@@ -29,7 +29,7 @@ public class Ui {
      * Prints greet message.
      */
     public void greet() {
-        response.append("Hello! This is Genie, your personal task tracker!");
+        response.append(GENIE_LOGO + "Hello! This is Genie, your personal task tracker!");
     }
 
     /**


### PR DESCRIPTION
The application boots up a blank window that waits for user's input.

Receiving Genie's greeting first gives a more 'complete' appearance and ensures that the application has started successfully.

Follows weak SLAP principle as there is no abstraction of the greeting message due to FXML load exception when done so.